### PR TITLE
Hygiene and robustness: go vet clean, callback race fix, static-checks CI

### DIFF
--- a/.github/workflows/basic_test.yml
+++ b/.github/workflows/basic_test.yml
@@ -7,32 +7,25 @@ on:
   pull_request:
 
 jobs:
-  # static-checks:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Check out repository code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: '0'
-      # - name: Check License Header
-      #   uses: apache/skywalking-eyes/header@main
-      # - name: Setup Go
-      #   uses: actions/setup-go@v5
-      #   with:
-      #     go-version: '1.20'
-      # - name: Setup goimports
-      #   run: go install golang.org/x/tools/cmd/goimports@v0.13.0
-      # - name: Check go.mod and go.sum
-      #   run: go mod tidy && git diff --exit-code
-      # - name: Check format
-      #   run: goimports -l -w . && git diff --exit-code
-      # - name: Run vet check
-      #   run: go vet ./...
-      # - name: Run linters
-      #   uses: golangci/golangci-lint-action@v3
-      #   with:
-      #     version: v1.54.2
-      #     skip-pkg-cache: true
+  static-checks:
+    runs-on: ubuntu-latest
+    steps:
+    - name: set up go 1.x
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: check gofmt
+      run: |
+        unformatted=$(gofmt -l .)
+        if [ -n "$unformatted" ]; then
+          echo "These files are not gofmt-formatted:"
+          echo "$unformatted"
+          exit 1
+        fi
+    - name: vet
+      run: go vet ./...
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/example/relay/relay.go
+++ b/example/relay/relay.go
@@ -7,14 +7,16 @@ import (
 	"github.com/elkanatovey/dataLink_relay/pkg/relay"
 	"github.com/elkanatovey/dataLink_relay/pkg/utils/logutils"
 	"net/http"
+	"time"
 )
 
-func StartRelay() { //@todo currently incorrect
+func StartRelay() {
 	logutils.SetLogStyle()
 	r := relay.NewRelay()
 	untrustedRelay := http.Server{
-		Addr:    fmt.Sprintf("localhost:%d", utils.ServerPort),
-		Handler: r.Mux,
+		Addr:              fmt.Sprintf("localhost:%d", utils.ServerPort),
+		Handler:           r.Mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 	if err := untrustedRelay.ListenAndServe(); err != nil {
 		if !errors.Is(err, http.ErrServerClosed) {

--- a/pkg/relay/connecting_client_db.go
+++ b/pkg/relay/connecting_client_db.go
@@ -56,14 +56,31 @@ func (db *connectingClientDB) RemoveConnectingClient(id string) {
 	db.mx.Unlock()
 }
 
-// NotifyConnectingClient return an error if the server to access does not exist in the db nil otherwise
+// NotifyConnectingClient hands a callback socket to a waiting client. It returns an error if the client is not
+// registered or already has a pending socket; in that case the caller still owns connection and must close it.
 func (db *connectingClientDB) NotifyConnectingClient(id string, connection *ServerConn) error {
 	db.mx.RLock()
 	defer db.mx.RUnlock()
 	if importer, ok := db.connectingClients[id]; ok {
-		importer.sockPassCh <- connection
-		return nil
+		select {
+		case importer.sockPassCh <- connection:
+			return nil
+		default:
+			return errors.New("client: " + id + " already has a pending connection")
+		}
 	}
-	var ErrNotFound = errors.New("server: " + id + " was not found")
-	return ErrNotFound
+	return errors.New("server: " + id + " was not found")
+}
+
+// removeAndDrainConnectingClient removes a client that stopped waiting and closes any callback socket that was
+// delivered but never consumed, so a late callback cannot leak the underlying connection.
+func (db *connectingClientDB) removeAndDrainConnectingClient(id string, imp *ConnectingClient) {
+	db.RemoveConnectingClient(id)
+	select {
+	case sc := <-imp.sockPassCh:
+		if sc != nil && sc.conn != nil {
+			sc.conn.Close()
+		}
+	default:
+	}
 }

--- a/pkg/relay/connecting_client_db_test.go
+++ b/pkg/relay/connecting_client_db_test.go
@@ -50,7 +50,6 @@ var importerName = "bb"
 func TestImporterDB_NotifyImporter(t *testing.T) {
 	type fields struct {
 		importers map[string]*ConnectingClient
-		mx        sync.RWMutex
 	}
 	type args struct {
 		id         string
@@ -67,7 +66,6 @@ func TestImporterDB_NotifyImporter(t *testing.T) {
 			name: "basic_test",
 			fields: fields{
 				map[string]*ConnectingClient{importerName: InitConnectingClient(context.TODO())},
-				sync.RWMutex{},
 			},
 			args: args{
 				importerName,
@@ -81,7 +79,6 @@ func TestImporterDB_NotifyImporter(t *testing.T) {
 			name: "basic_test2",
 			fields: fields{
 				map[string]*ConnectingClient{importerName: InitConnectingClient(context.TODO())},
-				sync.RWMutex{},
 			},
 			args: args{
 				importerName + "not",

--- a/pkg/relay/connecting_client_db_test.go
+++ b/pkg/relay/connecting_client_db_test.go
@@ -102,3 +102,44 @@ func TestImporterDB_NotifyImporter(t *testing.T) {
 		})
 	}
 }
+
+type closeSpyConn struct {
+	connTester
+	closed bool
+}
+
+func (c *closeSpyConn) Close() error {
+	c.closed = true
+	return nil
+}
+
+func TestRemoveAndDrainClosesUndeliveredSocket(t *testing.T) {
+	db := initConnectingClientDB()
+	imp := InitConnectingClient(context.TODO())
+	db.AddConnectingClient("k", imp)
+
+	spy := &closeSpyConn{}
+	imp.sockPassCh <- &ServerConn{conn: spy}
+
+	db.removeAndDrainConnectingClient("k", imp)
+
+	if !spy.closed {
+		t.Fatal("expected undelivered callback socket to be closed")
+	}
+	if err := db.NotifyConnectingClient("k", &ServerConn{}); err == nil {
+		t.Fatal("expected client to be removed from db")
+	}
+}
+
+func TestNotifyConnectingClientAlreadyPending(t *testing.T) {
+	db := initConnectingClientDB()
+	imp := InitConnectingClient(context.TODO())
+	db.AddConnectingClient("k", imp)
+
+	if err := db.NotifyConnectingClient("k", &ServerConn{}); err != nil {
+		t.Fatalf("first notify should succeed: %v", err)
+	}
+	if err := db.NotifyConnectingClient("k", &ServerConn{}); err == nil {
+		t.Fatal("expected error when a socket is already pending")
+	}
+}

--- a/pkg/relay/listening_server_db_test.go
+++ b/pkg/relay/listening_server_db_test.go
@@ -23,7 +23,6 @@ var connReq2 = api.ConnectionRequest{
 func TestExporterDB_NotifyExporter(t *testing.T) {
 	type fields struct {
 		exporters map[string]*ListeningServer
-		mx        sync.RWMutex
 	}
 	type args struct {
 		id  string
@@ -38,7 +37,7 @@ func TestExporterDB_NotifyExporter(t *testing.T) {
 
 		{
 			name:   "basic_test",
-			fields: fields{map[string]*ListeningServer{exporterName: InitListeningServer(context.TODO())}, sync.RWMutex{}},
+			fields: fields{map[string]*ListeningServer{exporterName: InitListeningServer(context.TODO())}},
 			args: []args{
 				{exporterName, InitClientData(connReq1)},
 				{exporterName, InitClientData(connReq2)},
@@ -47,7 +46,7 @@ func TestExporterDB_NotifyExporter(t *testing.T) {
 		},
 		{
 			name:   "basic_test2",
-			fields: fields{map[string]*ListeningServer{exporterName: InitListeningServer(context.TODO())}, sync.RWMutex{}},
+			fields: fields{map[string]*ListeningServer{exporterName: InitListeningServer(context.TODO())}},
 			args: []args{
 				{exporterName, InitClientData(connReq2)},
 			},
@@ -55,7 +54,7 @@ func TestExporterDB_NotifyExporter(t *testing.T) {
 		},
 		{
 			name:   "multiple_notifications_test",
-			fields: fields{map[string]*ListeningServer{exporterName: InitListeningServer(context.TODO())}, sync.RWMutex{}},
+			fields: fields{map[string]*ListeningServer{exporterName: InitListeningServer(context.TODO())}},
 			args: []args{
 				{exporterName, InitClientData(connReq1)},
 				{exporterName, InitClientData(connReq2)},

--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -166,7 +166,7 @@ func HandleClientConnection(relayState *RelayData) http.HandlerFunc {
 		// register the waiting client before notifying the server so a fast callback cannot arrive first
 		imp := InitConnectingClient(r.Context())
 		relayState.AddConnectingClient(getWaitingClientId(cr), imp)
-		defer relayState.RemoveConnectingClient(getWaitingClientId(cr))
+		defer relayState.removeAndDrainConnectingClient(getWaitingClientId(cr), imp)
 
 		imd := InitClientData(cr)
 		err = relayState.NotifyListeningServer(cr.ServerID, imd)
@@ -205,6 +205,7 @@ func HandleClientConnection(relayState *RelayData) http.HandlerFunc {
 		clientConn := hijackConn(w)
 		if clientConn == nil {
 			relayState.logger.Errorln("server does not support hijacking")
+			serverConn.conn.Close()
 			return
 		}
 
@@ -253,6 +254,10 @@ func HandleServerCallBackConnection(relayState *RelayData) http.HandlerFunc {
 		err = relayState.NotifyConnectingClient(getCallingServerId(ca), cn)
 		if err != nil {
 			relayState.logger.Errorln(err)
+			// the waiting client is gone; close the hijacked socket so it is not leaked
+			if conn != nil {
+				conn.Close()
+			}
 		}
 
 		return

--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -120,7 +120,7 @@ func HandleServerLongTermConnection(relayState *RelayData) http.HandlerFunc {
 			relayState.logger.Infof(" exporter %s stopped listening", req.ServerID)
 			close(connectionRequests.serverNotificationCh)
 			for connectionRequest := range connectionRequests.serverNotificationCh {
-				connectionRequest.resultNotificationCh <- api.ForwardingSuccessNotification{api.NoteServerConnLost, nil}
+				connectionRequest.resultNotificationCh <- api.ForwardingSuccessNotification{Message: api.NoteServerConnLost}
 			}
 
 		}()
@@ -133,17 +133,17 @@ func HandleServerLongTermConnection(relayState *RelayData) http.HandlerFunc {
 			event, err := api.MarshalToSSEEvent(&importer.msg)
 			if err != nil {
 				relayState.logger.Errorln(err)
-				importer.resultNotificationCh <- api.ForwardingSuccessNotification{api.NoteFail, err}
+				importer.resultNotificationCh <- api.ForwardingSuccessNotification{Message: api.NoteFail, Error: err}
 			}
 
 			_, err = fmt.Fprint(w, event)
 			if err != nil {
 				relayState.logger.Errorln(err)
-				importer.resultNotificationCh <- api.ForwardingSuccessNotification{api.NoteFail, err}
+				importer.resultNotificationCh <- api.ForwardingSuccessNotification{Message: api.NoteFail, Error: err}
 			}
 
 			flusher.Flush()
-			importer.resultNotificationCh <- api.ForwardingSuccessNotification{api.NotePassed, nil}
+			importer.resultNotificationCh <- api.ForwardingSuccessNotification{Message: api.NotePassed}
 		}
 
 	}
@@ -163,8 +163,12 @@ func HandleClientConnection(relayState *RelayData) http.HandlerFunc {
 		}
 		relayState.logger.Infof("connection request server: %s, client: %s", cr.ServerID, cr.ClientID)
 
-		imd := InitClientData(cr)
+		// register the waiting client before notifying the server so a fast callback cannot arrive first
+		imp := InitConnectingClient(r.Context())
+		relayState.AddConnectingClient(getWaitingClientId(cr), imp)
+		defer relayState.RemoveConnectingClient(getWaitingClientId(cr))
 
+		imd := InitClientData(cr)
 		err = relayState.NotifyListeningServer(cr.ServerID, imd)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -177,10 +181,6 @@ func HandleClientConnection(relayState *RelayData) http.HandlerFunc {
 			http.Error(w, res.Error.Error(), http.StatusBadRequest)
 			return
 		}
-		imp := InitConnectingClient(r.Context())
-
-		relayState.AddConnectingClient(getWaitingClientId(cr), imp)
-		defer relayState.RemoveConnectingClient(getWaitingClientId(cr))
 
 		var serverConn *ServerConn
 		select {

--- a/pkg/tcp_endpoints/listener.go
+++ b/pkg/tcp_endpoints/listener.go
@@ -11,13 +11,16 @@ import (
 
 const bufferSize = 100
 
+// connRequestResult carries either a received connection request or the error that ended the listen stream
+type connRequestResult struct {
+	*api.ConnectionRequest
+	error
+}
+
 // RelayListener listens for incoming connections via a relay over a http sse connection.
 type RelayListener struct {
 	manager       *listenerManager //should this be promoted?
-	reqHandlingCh chan struct {
-		*api.ConnectionRequest
-		error
-	}
+	reqHandlingCh chan connRequestResult
 	reqErrCh      chan error
 	ctx           context.Context
 	closeListener context.CancelCauseFunc //calling this CancelFunc will close the persistent connection maintained by listen_internal()
@@ -82,11 +85,8 @@ func NewRelayListener(relayURL string) RelayListener {
 	ctx, cancel := context.WithCancelCause(context.Background())
 
 	listener := RelayListener{
-		manager: newListenerManager(relayURL),
-		reqHandlingCh: make(chan struct {
-			*api.ConnectionRequest
-			error
-		}, bufferSize),
+		manager:       newListenerManager(relayURL),
+		reqHandlingCh: make(chan connRequestResult, bufferSize),
 		reqErrCh:      make(chan error, 1),
 		ctx:           ctx,
 		closeListener: cancel,
@@ -114,10 +114,10 @@ func (r ListenerAddress) Network() string {
 	return "tcp"
 }
 
-// String is the address that a RelayListener is listening on. It panics of the RelayListener hasn't started listening
+// String is the address that a RelayListener is listening on, or a placeholder if it has not started listening yet
 func (r ListenerAddress) String() string {
 	if r.Name != "" {
 		return r.Name
 	}
-	panic("listener has not started listening")
+	return "<relay listener not started>"
 }

--- a/pkg/tcp_endpoints/listener_manager.go
+++ b/pkg/tcp_endpoints/listener_manager.go
@@ -38,10 +38,7 @@ func newListenerManager(relayAddr string) *listenerManager {
 // listenInternal maintains the persistent connection through which clients send connection requests,
 // the listening address of the server is only set once it calls listenInternal
 // errors are propagated through the passed in channel, canceling the context will close both passed in channels
-func (s *listenerManager) listenInternal(ctx context.Context, handlingCH chan struct {
-	*api.ConnectionRequest
-	error
-},
+func (s *listenerManager) listenInternal(ctx context.Context, handlingCH chan connRequestResult,
 	errCH chan error, address string) error {
 	s.listeningAddress = ListenerAddress{address}
 
@@ -79,19 +76,13 @@ func (s *listenerManager) listenInternal(ctx context.Context, handlingCH chan st
 					}
 
 					//send off to be handled
-					handlingCH <- struct {
-						*api.ConnectionRequest
-						error
-					}{nil, err}
+					handlingCH <- connRequestResult{nil, err}
 					return
 				}
 
 				//sendoff to be handled
 				s.logger.Infof("received connection request from: %s", event.ClientID)
-				handlingCH <- struct {
-					*api.ConnectionRequest
-					error
-				}{event, nil}
+				handlingCH <- connRequestResult{event, nil}
 			}
 		}
 	}()

--- a/pkg/tcp_endpoints/listener_manager_test.go
+++ b/pkg/tcp_endpoints/listener_manager_test.go
@@ -38,11 +38,7 @@ func TestListenerManager_listenInternal(t *testing.T) {
 	exportingServer := newListenerManager(relayServer.Listener.Addr().String())
 
 	// channel to receive connrequests
-	handlingChennel := make(chan struct {
-		*api.ConnectionRequest
-		error
-	},
-		100)
+	handlingChennel := make(chan connRequestResult, 100)
 	errChan := make(chan error, 1)
 	ctx, cancel := context.WithCancel(context.Background()) // need to add  sse events to server to send + spin up gouroutine for export logic
 


### PR DESCRIPTION
## Summary
Follow-up hygiene + robustness pass (security / MTLS round-trip work is tracked separately). Also fixes a real callback race surfaced by the end-to-end test added in #2.

## Changes
- **Fix a client-callback registration race.** `HandleClientConnection` registered the connecting client only *after* notifying the listening server, so a fast server callback could arrive before the client was in the DB — the callback was dropped and the client blocked until timeout. The client is now registered *before* the server is notified. (The `-race` e2e test reproduced this reliably.)
- **`go vet` is now clean:** keyed the `api.ForwardingSuccessNotification` struct literals, and dropped an unused (lock-copying) `mx` field from the two DB table tests.
- **`ListenerAddress.String()` no longer panics** when the listener hasn't started — it returns a placeholder, which is the right contract for `net.Addr.String()` (safe to log).
- **Named the repeated anonymous channel struct** `struct { *api.ConnectionRequest; error }` as `connRequestResult`.
- **Example relay** sets `ReadHeaderTimeout` (Slowloris guard) and drops the stale `//@todo currently incorrect`.
- **CI:** replaced the commented-out `static-checks` job with a working one running `gofmt` and `go vet` on Go 1.23.

## Testing
- `gofmt -l .` clean, `go vet ./...` clean, `go build ./...`
- `go test -race -count=5 ./...` — all green (e2e stable, ~1s vs the prior 30s timeout).

## Not included
- Registration auth and MTLS round-trip reduction (owner is handling separately).
- golangci-lint / license-header / goimports checks (the old commented scaffolding) — can be added later.