### PR TITLE
Fix intermittent tunnel hang: bytes lost during CONNECT handoff

### DIFF
--- a/pkg/relay/relay_helper.go
+++ b/pkg/relay/relay_helper.go
@@ -30,8 +30,24 @@ func hijackConn(w http.ResponseWriter) net.Conn {
 	}
 	w.WriteHeader(http.StatusOK) //should this be here?
 	// Hijack the connection
-	conn, _, _ := hj.Hijack()
-	return conn
+	conn, bufrw, err := hj.Hijack()
+	if err != nil {
+		return nil
+	}
+	// Hijack can hand back bytes the client has already sent, sitting unread in the server's read
+	// buffer. Reading straight from conn would silently drop them, so read through bufrw instead.
+	return &hijackedConn{Conn: conn, reader: bufrw.Reader}
+}
+
+// hijackedConn reads through the buffered reader returned by http.Hijacker so that data the HTTP
+// server had already read off the socket is delivered. Everything else is the raw connection.
+type hijackedConn struct {
+	net.Conn
+	reader io.Reader
+}
+
+func (c *hijackedConn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
 }
 
 // uniteConnections glues an importer connection with an exporter connection

--- a/pkg/utils/httputils/httputils.go
+++ b/pkg/utils/httputils/httputils.go
@@ -1,6 +1,7 @@
 package httputils
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -83,14 +84,16 @@ func Delete(url string, jsonData []byte, cl http.Client) ([]byte, error) {
 	return body, nil
 }
 
-type myConn struct {
+// tunnelConn is the connection handed back once a CONNECT has been accepted. Reads go through the
+// buffered reader that parsed the response, so any bytes it read ahead of the response are still
+// delivered to the caller. Everything else is the raw connection.
+type tunnelConn struct {
 	net.Conn
-	r *http.Response
+	reader io.Reader
 }
 
-func (a myConn) Close() error {
-	a.r.Body.Close()
-	return a.Conn.Close()
+func (c *tunnelConn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
 }
 
 // Connect is a convenience function to issue a CONNECT request
@@ -101,25 +104,34 @@ func Connect(address, url string, jsonData string) (net.Conn, error) {
 	}
 
 	log.Infof("Send Connect request to url: %v", url)
-	client := http.Client{Transport: &http.Transport{Dial: connDialer{c}.Dial}}
 	req, err := http.NewRequest(http.MethodConnect, url, bytes.NewBuffer([]byte(jsonData)))
 	if err != nil {
+		c.Close()
 		return nil, err
 	}
 
-	resp, err := client.Do(req)
+	// Write the request straight to the connection rather than going through an http.Transport. A
+	// Transport keeps ownership of the socket and reads it in the background, so tunnel bytes that
+	// arrive after the response can end up in its buffer where the caller can never see them.
+	if err := req.Write(c); err != nil {
+		log.Errorln(err)
+		c.Close()
+		return nil, err
+	}
 
+	br := bufio.NewReader(c)
+	resp, err := http.ReadResponse(br, req)
 	if err != nil {
 		log.Errorln(err)
+		c.Close()
 		return nil, err
 	}
-	mc := myConn{c, resp}
 	if resp.StatusCode != http.StatusOK {
+		c.Close()
 		return nil, fmt.Errorf("connect response code: %v", resp.StatusCode)
 	}
 
-	return mc, nil
-
+	return &tunnelConn{Conn: c, reader: br}, nil
 }
 
 func dial(addr string) (net.Conn, error) {
@@ -132,13 +144,4 @@ func dial(addr string) (net.Conn, error) {
 	log.Infof("Finish dial to address: %v\n", addr)
 
 	return c, err
-}
-
-type connDialer struct {
-	c net.Conn
-}
-
-// Dial (network , addr)fakes a connect to an existing connection
-func (cd connDialer) Dial(_, _ string) (net.Conn, error) {
-	return cd.c, nil
 }


### PR DESCRIPTION
Fixes the failure on main. Not caused by #9 — I reproduced it on `c79322c`, the commit *before* that merge, so #9 only shifted timing enough to surface it. Only the 1.25 job hit it; 1.26 passed, and both passed on the PR run.

## Symptom
`TestRelayEndToEndSealed` hangs until the 10 minute test timeout. The goroutine dump shows everyone blocked on a read: both relay copiers, the dialling client, and the echo server. The client's first write had vanished.

## Cause 1 — `httputils.Connect` hands back a socket it does not own
It issued the CONNECT through an `http.Transport`, then returned the raw `net.Conn`:

```go
client := http.Client{Transport: &http.Transport{Dial: connDialer{c}.Dial}}
resp, err := client.Do(req)
return myConn{c, resp}, nil
```

The Transport keeps ownership of that socket and its `persistConn.readLoop` goes on reading in the background. Tunnel bytes arriving shortly after the response get buffered inside the Transport, where a caller reading the raw conn can never see them. Whether they land in that buffer or stay in the socket is pure timing — hence a flake.

Now the request is written straight to the connection and the response parsed with a `bufio.Reader` we keep, returning a conn that reads through it. The unused `connDialer` shim goes away with it.

## Cause 2 — `hijackConn` discards the buffered reader
```go
conn, _, _ := hj.Hijack()
```

`Hijack()` returns a `*bufio.ReadWriter` that may already hold bytes the client sent, and net/http documents exactly this. Reading from the raw conn drops them. The error was discarded too. Now reads go through that reader.

I confirmed this one directly: instrumenting the discard showed the hang occurred in precisely the run where buffered bytes were thrown away.

## This is not a test-only problem
Any caller writing immediately after dialling can lose its first bytes. The mTLS path does exactly that — `tls.Client(...).HandshakeContext` sends the ClientHello straight after `DialTCP` — so a lost first write stalls the handshake rather than corrupting anything. Silent, intermittent, and hard to attribute.

## Verification
- `TestRelayEndToEnd*` × 500: previously hung, now 1.6s.
- Full suite `-race -count=20`: clean.
- mTLS demo end to end against `relay -require-control-tls`: echo round-trips.